### PR TITLE
feat(pre-commit): add docker-image pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
 
   - repo: local
     hooks:
-      - id: ggshield
+      - id: ggshield-local
         name: GitGuardian Shield
         entry: ggshield scan -m pre-commit
         language: python
@@ -52,8 +52,8 @@ repos:
         stages: [commit]
 
   - repo: https://github.com/gitguardian/gg-shield
-    rev: v1.0.1
+    rev: v1.0.2
     hooks:
-      - id: commit-ggshield
+      - id: ggshield
         language_version: python3
         stages: [commit]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,3 +8,7 @@
   language: python
   entry: ggshield
   args: ['scan', '-m', 'pre-commit']
+- id: docker-ggshield
+  name: GitGuardian Shield (docker)
+  language: docker_image
+  entry: -e GITGUARDIAN_API_KEY gitguardian/ggshield:latest ggshield scan -m pre-commit

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ repos:
   - repo: https://github.com/gitguardian/gg-shield
     rev: main
     hooks:
-      - id: commit-ggshield
+      - id: ggshield
         language_version: python3
         stages: [commit]
 ```


### PR DESCRIPTION
- Adds `docker_image` pre-commit hook as `docker-ggshield`
- Change default recommended pre-commit hook to `ggshield`, `commit-ggshield` will be deprecated in the future