### PR TITLE
fix(shell): fix compatibility issue with python 3.6

### DIFF
--- a/ggshield/git_shell.py
+++ b/ggshield/git_shell.py
@@ -5,6 +5,7 @@ import click
 
 
 COMMAND_TIMEOUT = 45
+GIT_PATH = "git"
 
 
 def is_git_dir() -> bool:
@@ -19,7 +20,7 @@ def check_git_dir():
     """ Check if folder is git directory. """
     check_git_installed()
     with subprocess.Popen(
-        ["git", "status"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        [GIT_PATH, "status"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
     ) as process:
         if process.wait():
             raise click.ClickException("Not a git directory.")
@@ -28,7 +29,7 @@ def check_git_dir():
 def check_git_installed():
     """ Check if git is installed. """
     with subprocess.Popen(
-        ["git", "--help"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        [GIT_PATH, "--help"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
     ) as process:
         if process.wait():
             raise click.ClickException("Git is not installed.")
@@ -38,10 +39,9 @@ def shell(command: List[str]) -> List[str]:
     """ Execute a command in a subprocess. """
     try:
         result = subprocess.run(
-            command, check=True, capture_output=True, timeout=COMMAND_TIMEOUT
+            command, check=True, stdout=subprocess.PIPE, timeout=COMMAND_TIMEOUT
         )
-        output = result.stdout.decode("utf-8").rstrip().split("\n")
-        return output
+        return result.stdout.decode("utf-8").rstrip().split("\n")
     except subprocess.CalledProcessError:
         pass
     except subprocess.TimeoutExpired:
@@ -58,8 +58,8 @@ def get_list_commit_SHA(commit_range: str) -> List[str]:
     :param commit_range: A range of commits (ORIGIN...HEAD)
     """
 
-    return shell(["git", "rev-list", "--reverse", commit_range])
+    return shell([GIT_PATH, "rev-list", "--reverse", commit_range])
 
 
 def get_list_all_commits() -> List[str]:
-    return shell(["git", "rev-list", "--reverse", "--all"])
+    return shell([GIT_PATH, "rev-list", "--reverse", "--all"])

--- a/ggshield/install.py
+++ b/ggshield/install.py
@@ -29,7 +29,7 @@ def install_global(force: bool) -> int:
 
     if not hook_dir_path:
         hook_dir_path = os.path.expanduser("~/.git/hooks")
-        subprocess.call(["git", "config", "--global", "core.hooksPath", hook_dir_path])
+        subprocess.run(["git", "config", "--global", "core.hooksPath", hook_dir_path])
 
     return create_hook(hook_dir_path, force)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ use_parentheses=true
 known_third_party = click,mock,pygitguardian,pytest,setuptools,snapshottest,vcr,yaml
 
 [coverage:report]
-omit = tests/*,ggshield/git_shell.py
+omit = tests/*
 fail_under = 80
 show_missing = True
 

--- a/tests/test_git_shell.py
+++ b/tests/test_git_shell.py
@@ -1,0 +1,11 @@
+from ggshield.git_shell import is_git_dir, shell
+
+
+def test_git_shell():
+    assert "See 'git help git' for an overview of the system." in shell(
+        ["git", "--help"]
+    )
+
+
+def test_is_git_dir():
+    assert is_git_dir()


### PR DESCRIPTION
- removes `capture_output` which was only added in python 3.7.
- removes `git_shell` from coverage exclusions 