### PR TITLE
Increase timeout to list git ignored files to 10min

### DIFF
--- a/ggshield/filter.py
+++ b/ggshield/filter.py
@@ -118,7 +118,7 @@ def path_filter_set(top_dir: Path, paths_ignore: Iterable[str]) -> Set[str]:
             {
                 os.path.join(top_dir, filename)
                 for filename in shell_split(
-                    ["git", "ls-files", "-o", "-i", "--exclude-standard"]
+                    ["git", "ls-files", "-o", "-i", "--exclude-standard"], timeout=600
                 )
             }
         )

--- a/ggshield/git_shell.py
+++ b/ggshield/git_shell.py
@@ -39,7 +39,7 @@ def check_git_installed():
             raise click.ClickException("Git is not installed.")
 
 
-def shell(command: List[str]) -> str:
+def shell(command: List[str], timeout: int = COMMAND_TIMEOUT) -> str:
     """ Execute a command in a subprocess. """
     try:
         result = subprocess.run(
@@ -47,7 +47,7 @@ def shell(command: List[str]) -> str:
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            timeout=COMMAND_TIMEOUT,
+            timeout=timeout,
         )
         return result.stdout.decode("utf-8").rstrip()
     except subprocess.CalledProcessError:
@@ -60,8 +60,8 @@ def shell(command: List[str]) -> str:
     return ""
 
 
-def shell_split(command: List[str]) -> List[str]:
-    return shell(command).split("\n")
+def shell_split(command: List[str], **kwargs) -> List[str]:
+    return shell(command, **kwargs).split("\n")
 
 
 def get_list_commit_SHA(commit_range: str) -> List[str]:


### PR DESCRIPTION
Increase timeout of `git ls-files` for ignored file listing to handle repositories with a lot of ignored file in the working directory.

This is a temporary fix and refactoring the ignore file to avoid having to run this git command will need to be done.
