### PR TITLE
Improve filter performance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,9 +51,9 @@ repos:
     hooks:
       - id: ggshield-local
         name: GitGuardian Shield
-        entry: ggshield scan pre-commit
-        language: python
-        language_version: python3
+        entry: pipenv run ggshield scan pre-commit
+        language: system
+        types: [python]
         stages: [commit]
 
   - repo: https://github.com/gitguardian/gg-shield

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,27 +23,21 @@ repos:
       - id: check-added-large-files
       - id: check-yaml
 
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
-        args: [--settings-path, ./]
-
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.4.2
+    rev: v5.5.1
     hooks:
       - id: isort
         args: [--settings-path, setup.cfg]
 
   - repo: https://github.com/Woile/commitizen
-    rev: v2.1.0
+    rev: v2.3.1
     hooks:
       - id: commitizen
         # don't forget to run pre-commit install --hook-type commit-msg for this hook to run
         stages: [commit-msg]
 
   - repo: https://github.com/prettier/prettier # to format JSON, YAML and markdown files among others
-    rev: 2.0.5
+    rev: 2.1.1
     hooks:
       - id: prettier
 
@@ -57,7 +51,7 @@ repos:
         stages: [commit]
 
   - repo: https://github.com/gitguardian/gg-shield
-    rev: v1.2.0
+    rev: v1.2.2
     hooks:
       - id: ggshield
         language_version: python3

--- a/ggshield/filter.py
+++ b/ggshield/filter.py
@@ -1,15 +1,12 @@
 import hashlib
 import math
 import operator
-import os
 import re
 from collections import OrderedDict
 from pathlib import Path
 from typing import Dict, Iterable, List, Set
 
 from pygitguardian.models import Match, PolicyBreak, ScanResult
-
-from .git_shell import GIT_PATH, is_git_dir, shell_split
 
 
 REGEX_MATCH_HIDE = re.compile(r"[^+\-\s]")
@@ -112,17 +109,6 @@ def path_filter_set(top_dir: Path, paths_ignore: Iterable[str]) -> Set[str]:
     for ignored in paths_ignore:
         filters.update({str(target) for target in top_dir.glob(ignored)})
 
-    if is_git_dir():
-        filters.update({str(target) for target in top_dir.glob(r".git/**/*")})
-        filters.update(
-            {
-                os.path.join(top_dir, filename)
-                for filename in shell_split(
-                    [GIT_PATH, "ls-files", "-o", "-i", "--exclude-standard"],
-                    timeout=600,
-                )
-            }
-        )
     return filters
 
 

--- a/ggshield/path.py
+++ b/ggshield/path.py
@@ -4,6 +4,8 @@ from typing import Iterable, List, Set, Union
 
 import click
 
+from ggshield.git_shell import git_ls, is_git_dir
+
 from .config import MAX_FILE_SIZE
 from .filter import path_filter_set
 from .scannable import File, Files
@@ -64,8 +66,14 @@ def get_filepaths(
                     click.format_filename(path), "Use --recursive to scan directories."
                 )
             top_dir = Path(path)
-            _targets = {str(target) for target in top_dir.rglob(r"*")}
+
+            if is_git_dir(path):
+                _targets = {os.path.join(path, target) for target in git_ls(path)}
+            else:
+                _targets = {str(target) for target in top_dir.rglob(r"*")}
+
             _targets.difference_update(path_filter_set(top_dir, paths_ignore))
+
             targets.update(_targets)
     return targets
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,12 +8,8 @@ exclude = **/snapshots/*.py
 description-file = README.md
 
 [isort]
-line_length = 88
+profile = black
 lines_after_imports = 2
-multi_line_output = 3
-include_trailing_comma = true
-use_parentheses=true
-known_third_party = click,dotenv,mock,pygitguardian,pytest,setuptools,snapshottest,vcr,yaml
 
 [coverage:report]
 omit = tests/*


### PR DESCRIPTION

- Remove need for building git filter set for commits (much faster pre-commit and commit-range scan).
- Use `.gitignore` of target if it's not the working directory.
- Use `git ls-files` for path if target is a repo (faster)

Average 2x improvement

Example on mid-sized project:
old - 0:04.26 elapsed
new - 0:02.54 elapsed
