### PR TITLE
feat(ignore_cmd): add ignore --last-found command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ venv.bak/
 
 # test file
 test-secret-files.json
+
+# cache
+.cache_ggshield

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ GITGUARDIAN_API_KEY=<GitGuardian API Key>
 
    - [Scan](#scan-command)
    - [Install](#install-command)
+   - [Ignore](#ignore-command)
 
 1. [Pre-commit](#pre-commit)
 
@@ -100,6 +101,7 @@ Options:
 Commands:
   install  Command to install a pre-commit hook (local or global).
   scan     Command to scan various contents.
+  ignore   Command to permanently ignore some secrets.
 ```
 
 ## Scan command
@@ -203,6 +205,24 @@ Options:
   -m, --mode [local|global]  Hook installation mode  [required]
   -f, --force                Force override
   -h, --help                 Show this message and exit.
+```
+
+## Ignore command
+
+The `ignore` command allows you to ignore some secrets.
+For the time being, it only handles the `--last-found` option that ignore all secrets found by the last run `scan` command.
+Under the hood, these secrets are added to the matches-ignore section of your local config file (if no local config file is found, a `.gitguardian.yaml` file is created).
+
+Warning: Using this command will discard any comment present in the config file.
+
+```shell
+Usage: ggshield ignore
+
+  Command to ignore all secrets found by the previous scan.
+
+Options:
+  -h, --help                 Show this message and exit.
+  --last-found               Ignore all secrets found by last run scan
 ```
 
 # Configuration

--- a/ggshield/ci.py
+++ b/ggshield/ci.py
@@ -225,6 +225,7 @@ def ci_cmd(ctx: click.Context) -> int:  # pragma: no cover
 
         return scan_commit_range(
             client=ctx.obj["client"],
+            cache=ctx.obj["cache"],
             commit_list=commit_list,
             output_handler=ctx.obj["output_handler"],
             verbose=config.verbose,

--- a/ggshield/cmd.py
+++ b/ggshield/cmd.py
@@ -10,9 +10,10 @@ from pygitguardian import GGClient
 from ggshield.output import JSONHandler, OutputHandler, TextHandler
 
 from .ci import ci_cmd
-from .config import CONTEXT_SETTINGS, Config, load_dot_env
+from .config import CONTEXT_SETTINGS, Cache, Config, load_dot_env
 from .dev_scan import path_cmd, precommit_cmd, range_cmd, repo_cmd
 from .filter import path_filter_set
+from .ignore import ignore
 from .install import install
 
 
@@ -128,7 +129,8 @@ def exit_code(ctx: click.Context, exit_code: int, **kwargs: Any) -> None:
 
 
 @click.group(
-    context_settings=CONTEXT_SETTINGS, commands={"scan": scan, "install": install}
+    context_settings=CONTEXT_SETTINGS,
+    commands={"scan": scan, "install": install, "ignore": ignore},
 )
 @click.option(
     "-c",
@@ -148,6 +150,7 @@ def cli(ctx: click.Context, config_path: str, verbose: bool) -> None:
         Config.CONFIG_GLOBAL = []
 
     ctx.obj["config"] = Config()
+    ctx.obj["cache"] = Cache()
 
     if verbose is not None:
         ctx.obj["config"].verbose = verbose

--- a/ggshield/config.py
+++ b/ggshield/config.py
@@ -1,9 +1,12 @@
+import copy
+import json
 import os
 from typing import Any, Dict, List, NamedTuple
 
 import click
 import yaml
 from dotenv import load_dotenv
+from pygitguardian.models import PolicyBreak
 
 from .git_shell import get_git_root, is_git_dir
 from .text_utils import display_error
@@ -17,16 +20,27 @@ MAX_FILE_SIZE = 1048576
 CPU_COUNT = os.cpu_count() or 1
 
 
+class Attribute(NamedTuple):
+    name: str
+    default: Any
+
+
+def replace_in_keys(data: Dict, old_char: str, new_char: str) -> None:
+    """ Replace old_char with new_char in data keys. """
+    for key in list(data):
+        if old_char in key:
+            new_key = key.replace(old_char, new_char)
+            data[new_key] = data.pop(key)
+
+
 class Config:
     all_policies: bool
     api_url: str
     exit_zero: bool
-    verbose: bool
+    matches_ignore: set
+    paths_ignore: set
     show_secrets: bool
-
-    class Attribute(NamedTuple):
-        name: str
-        default: Any
+    verbose: bool
 
     CONFIG_LOCAL = ["./.gitguardian", "./.gitguardian.yml", "./.gitguardian.yaml"]
     CONFIG_GLOBAL = [
@@ -34,6 +48,7 @@ class Config:
         os.path.join(os.path.expanduser("~"), ".gitguardian.yml"),
         os.path.join(os.path.expanduser("~"), ".gitguardian.yaml"),
     ]
+    DEFAULT_CONFIG_LOCAL = "./.gitguardian.yaml"
 
     attributes: List[Attribute] = [
         Attribute("all_policies", False),
@@ -55,11 +70,14 @@ class Config:
         # Required for dynamic types on mypy
         return object.__getattribute__(self, name)
 
+    def get_attributes_keys(self) -> List:
+        return list(
+            list(zip(*self.attributes))[0]
+        )  # get list of first elements in tuple
+
     def update_config(self, **kwargs: Any) -> None:
         for key, item in kwargs.items():
-            if key in list(
-                list(zip(*self.attributes))[0]
-            ):  # get list of first elements in tuple
+            if key in self.get_attributes_keys():
                 if isinstance(item, list):
                     getattr(self, key).update(item)
                 else:
@@ -73,8 +91,8 @@ class Config:
 
         with open(filename, "r") as f:
             try:
-                _config = yaml.safe_load(f)
-                self.clean_keys(_config)
+                _config = yaml.safe_load(f) or {}
+                replace_in_keys(_config, "-", "_")
                 self.update_config(**_config)
             except Exception as e:
                 raise click.ClickException(
@@ -84,9 +102,7 @@ class Config:
         return True
 
     def load_configs(self, filenames: List[str]) -> None:
-        """
-        load_configs loads config files until one succeeds
-        """
+        """ Loads config files until one succeeds. """
         for filename in filenames:
             try:
                 if self.load_config(filename):
@@ -94,12 +110,42 @@ class Config:
             except Exception as exc:
                 click.echo(str(exc))
 
-    @staticmethod
-    def clean_keys(yaml_config: Dict) -> None:
-        for key in list(yaml_config):
-            if "-" in key:
-                new_key = key.replace("-", "_")
-                yaml_config[new_key] = yaml_config.pop(key)
+    def to_dict(self) -> Dict[str, Any]:
+        _config = {key: getattr(self, key) for key in self.get_attributes_keys()}
+        # Convert all sets into more human readable lists
+        for key in self.get_attributes_keys():
+            value = _config[key]
+            if type(value) is set:
+                _config[key] = list(value)
+        replace_in_keys(_config, "_", "-")
+        return _config
+
+    def save(self) -> bool:
+        """
+        Save config in the first CONFIG_LOCAL file.
+        If no local config file, creates a local .gitguardian.yaml
+        """
+        config_file = self.DEFAULT_CONFIG_LOCAL
+        for filename in self.CONFIG_LOCAL:
+            if os.path.isfile(filename):
+                config_file = filename
+                break
+
+        with open(config_file, "w") as f:
+            try:
+                stream = yaml.dump(self.to_dict(), default_flow_style=False)
+                f.write(stream.replace("- ", "  - "))
+
+            except Exception as e:
+                raise click.ClickException(
+                    f"Error while saving config in {config_file}:\n{str(e)}"
+                )
+        return True
+
+    def add_ignored_match(self, secret_hash: str) -> None:
+        """ Add secret to matches_ignore. """
+        current_ignored = self.matches_ignore
+        current_ignored.add(secret_hash)
 
 
 def load_dot_env() -> None:
@@ -121,3 +167,99 @@ def load_dot_env() -> None:
         if is_git_dir() and os.path.isfile(os.path.join(get_git_root(), ".env")):
             load_dotenv(os.path.join(get_git_root(), ".env"), override=True)
             return
+
+
+class Cache:
+
+    last_found_secrets: set
+
+    CACHE_FILENAME = "./.cache_ggshield"
+    attributes: List[Attribute] = [
+        Attribute("last_found_secrets", set()),
+    ]
+
+    def __init__(self) -> None:
+        self.purge()
+        self.load_cache()
+
+    def __getattr__(self, name: str) -> Any:
+        # Required for dynamic types on mypy
+        return object.__getattribute__(self, name)
+
+    def get_attributes_keys(self) -> List:
+        return list(
+            list(zip(*self.attributes))[0]
+        )  # get list of first elements in tuple
+
+    def create_empty_cache(self) -> None:
+        # Creates a new file
+        with open(self.CACHE_FILENAME, "w"):
+            pass
+
+    def load_cache(self) -> bool:
+        if not os.path.isfile(self.CACHE_FILENAME):
+            self.create_empty_cache()
+            return True
+
+        _cache: dict = {}
+        if os.stat(self.CACHE_FILENAME).st_size != 0:
+            with open(self.CACHE_FILENAME, "r") as f:
+                try:
+                    _cache = json.load(f)
+                    # Convert back all sets that were serialized as lists
+                    for attr in self.attributes:
+                        if type(attr.default) is set and attr.name in _cache:
+                            _cache[attr.name] = set(_cache[attr.name]) or set()
+                except Exception as e:
+                    raise click.ClickException(
+                        f"Parsing error while reading {self.CACHE_FILENAME}:\n{str(e)}"
+                    )
+        self.update_cache(**_cache)
+        return True
+
+    def update_cache(self, **kwargs: Any) -> None:
+        for key, item in kwargs.items():
+            if key in self.get_attributes_keys():
+                if isinstance(item, list):
+                    getattr(self, key).update(item)
+                else:
+                    setattr(self, key, item)
+            else:
+                click.echo("Unrecognized key in cache: {}".format(key))
+
+    def to_dict(self) -> Dict[str, Any]:
+        _cache = {key: getattr(self, key) for key in self.get_attributes_keys()}
+        # Convert all sets into list so they can be json serialized
+        for key in self.get_attributes_keys():
+            value = _cache[key]
+            if type(value) is set:
+                _cache[key] = list(value)
+        return _cache
+
+    def save(self) -> bool:
+        if not os.path.isfile(self.CACHE_FILENAME):
+            return False
+
+        with open(self.CACHE_FILENAME, "w") as f:
+            try:
+                json.dump(self.to_dict(), f)
+
+            except Exception as e:
+                raise click.ClickException(
+                    f"Error while saving cache in {self.CACHE_FILENAME}:\n{str(e)}"
+                )
+        return True
+
+    def purge(self) -> None:
+        for attr in self.attributes:
+            # Deep copy to avoid mutating the default value
+            default = copy.copy(attr.default)
+            setattr(self, attr.name, default)
+
+    def add_found_secret(self, hash: str) -> None:
+        self.last_found_secrets.add(hash)
+
+    def add_found_policy_break(self, policy_break: PolicyBreak) -> None:
+        if policy_break.policy.lower() == "secrets detection":
+            for match in policy_break.matches:
+                self.add_found_secret(match.match)

--- a/ggshield/ignore.py
+++ b/ggshield/ignore.py
@@ -1,0 +1,41 @@
+import sys
+
+import click
+
+from ggshield.config import Cache, Config
+
+
+@click.command()
+@click.option(
+    "--last-found",
+    is_flag=True,
+    help="Ignore secrets found in the last gg-shield scan run",
+)
+@click.pass_context
+def ignore(ctx: click.Context, last_found: bool) -> int:
+    """
+    Command to ignore some secrets.
+    """
+
+    if last_found:
+        config = ctx.obj["config"]
+        cache = ctx.obj["cache"]
+        nb = ignore_last_found(config, cache)
+        click.echo(
+            f"{nb} secrets have been added to your ignore list in"
+            " .gitguardian.yaml under matches-ignore section."
+        )
+
+    sys.exit(0)
+
+
+def ignore_last_found(config: Config, cache: Cache) -> int:
+    """
+    Add last found secrets from .cache_ggshield into ignored_matches
+    in the local .gitguardian.yaml config file so that they are ignored on next run
+    Secrets are added as `hash`
+    """
+    for secret in cache.last_found_secrets:
+        config.add_ignored_match(secret)
+    config.save()
+    return len(cache.last_found_secrets)

--- a/ggshield/scan/scannable.py
+++ b/ggshield/scan/scannable.py
@@ -8,7 +8,7 @@ from pygitguardian import GGClient
 from pygitguardian.config import MULTI_DOCUMENT_LIMIT
 from pygitguardian.models import ScanResult
 
-from ggshield.config import CPU_COUNT, MAX_FILE_SIZE
+from ggshield.config import CPU_COUNT, MAX_FILE_SIZE, Cache
 from ggshield.filter import remove_ignored_from_result
 from ggshield.git_shell import GIT_PATH, shell
 from ggshield.text_utils import STYLE, format_text
@@ -100,10 +100,12 @@ class Files:
     def scan(
         self,
         client: GGClient,
+        cache: Cache,
         matches_ignore: Iterable[str],
         all_policies: bool,
         verbose: bool,
     ) -> List[Result]:
+        cache.purge()
         scannable_list = self.scannable_list
         results = []
         chunks = []
@@ -127,6 +129,8 @@ class Files:
                 for index, scanned in enumerate(scan.scan_results):
                     remove_ignored_from_result(scanned, all_policies, matches_ignore)
                     if scanned.has_policy_breaks:
+                        for policy_break in scanned.policy_breaks:
+                            cache.add_found_policy_break(policy_break)
                         results.append(
                             Result(
                                 content=chunk[index]["document"],
@@ -135,7 +139,7 @@ class Files:
                                 filename=chunk[index]["filename"],
                             )
                         )
-
+        cache.save()
         return results
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ import vcr
 from pygitguardian import GGClient
 from pygitguardian.models import ScanResult
 
+from ggshield.config import Cache
+
 
 _MULTIPLE_SECRETS_PATCH = """@@ -0,0 +1,2 @@
 +FacebookAppKeys :
@@ -379,3 +381,10 @@ def client() -> GGClient:
     api_key = os.getenv("TEST_GITGUARDIAN_API_KEY", "1234567890")
     base_uri = os.getenv("TEST_GITGUARDIAN_API_URL", "https://api.gitguardian.com")
     return GGClient(api_key, base_uri)
+
+
+@pytest.fixture(scope="session")
+def cache() -> Cache:
+    c = Cache()
+    c.purge()
+    return c

--- a/tests/output/test_json_output.py
+++ b/tests/output/test_json_output.py
@@ -40,14 +40,18 @@ _EXPECT_NO_SECRET = {
         "_NO_SECRET",
     ],
 )
-def test_json_output(client, name, input_patch, expected, snapshot):
+def test_json_output(client, cache, name, input_patch, expected, snapshot):
     c = Commit()
     c._patch = input_patch
     handler = JSONHandler(verbose=True, show_secrets=False)
 
     with my_vcr.use_cassette(name):
         results = c.scan(
-            client=client, matches_ignore={}, all_policies=True, verbose=False
+            client=client,
+            cache=cache,
+            matches_ignore={},
+            all_policies=True,
+            verbose=False,
         )
 
         flat_results, exit_code = handler.process_scan(

--- a/tests/scan/test_scannable.py
+++ b/tests/scan/test_scannable.py
@@ -62,13 +62,17 @@ _EXPECT_NO_SECRET = {
         "_NO_SECRET",
     ],
 )
-def test_scan_patch(client, name, input_patch, expected):
+def test_scan_patch(client, cache, name, input_patch, expected):
     c = Commit()
     c._patch = input_patch
 
     with my_vcr.use_cassette(name):
         results = c.scan(
-            client=client, matches_ignore={}, all_policies=True, verbose=False
+            client=client,
+            cache=cache,
+            matches_ignore={},
+            all_policies=True,
+            verbose=False,
         )
         for result in results:
             if result.scan.policy_breaks:

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -1,0 +1,134 @@
+from mock import patch
+
+from ggshield.config import Cache, Config
+from ggshield.ignore import ignore_last_found
+from ggshield.scan import Commit
+from tests.conftest import _MULTIPLE_SECRETS, my_vcr
+
+
+FOUND_SECRETS = {
+    "5434",
+    "google.com",
+    "m42ploz2wd",
+    "root",
+}
+
+
+@patch("ggshield.config.Config.CONFIG_LOCAL", ["/tmp/.gitguardian.yml"])
+@patch("ggshield.config.Config.DEFAULT_CONFIG_LOCAL", "/tmp/.gitguardian.yml")
+def test_cache_catches_last_found_secrets(client):
+    """
+    GIVEN an empty cache and an empty config matches-ignore section
+    WHEN I run a scan with multiple secrets
+    THEN cache last_found_secrets is updated with these secrets and saved
+    """
+    c = Commit()
+    c._patch = _MULTIPLE_SECRETS
+    config = Config()
+    setattr(config, "matches_ignore", set())
+    cache = Cache()
+    cache.purge()
+    assert cache.last_found_secrets == set()
+
+    with my_vcr.use_cassette("multiple_secrets"):
+        c.scan(
+            client=client,
+            cache=cache,
+            matches_ignore=config.matches_ignore,
+            all_policies=True,
+            verbose=False,
+        )
+    assert config.matches_ignore == set()
+    assert cache.last_found_secrets == FOUND_SECRETS
+    cache.load_cache()
+    assert cache.last_found_secrets == FOUND_SECRETS
+
+
+@patch("ggshield.config.Config.CONFIG_LOCAL", ["/tmp/.gitguardian.yml"])
+@patch("ggshield.config.Config.DEFAULT_CONFIG_LOCAL", "/tmp/.gitguardian.yml")
+def test_cache_catches_nothing(client):
+    """
+    GIVEN a cache of last found secrets same as config ignored-matches
+    WHEN I run a scan (therefore finding no secret)
+    THEN config matches is unchanged and cache is empty
+    """
+    c = Commit()
+    c._patch = _MULTIPLE_SECRETS
+    config = Config()
+    config.matches_ignore = FOUND_SECRETS
+    cache = Cache()
+    cache.last_found_secrets = FOUND_SECRETS
+
+    with my_vcr.use_cassette("multiple_secrets"):
+        results = c.scan(
+            client=client,
+            cache=cache,
+            matches_ignore=config.matches_ignore,
+            all_policies=True,
+            verbose=False,
+        )
+        assert results == []
+        assert config.matches_ignore == FOUND_SECRETS
+        assert cache.last_found_secrets == set()
+
+
+@patch("ggshield.config.Config.CONFIG_LOCAL", ["/tmp/.gitguardian.yml"])
+@patch("ggshield.config.Config.DEFAULT_CONFIG_LOCAL", "/tmp/.gitguardian.yml")
+def test_ignore_last_found(client):
+    """
+    GIVEN a cache of last found secrets not empty
+    WHEN I run a ignore last found command
+    THEN config ignored-matches is updated accordingly
+    """
+    config = Config()
+    setattr(config, "matches_ignore", set())
+
+    cache = Cache()
+    cache.last_found_secrets = FOUND_SECRETS
+    ignore_last_found(config, cache)
+    assert config.matches_ignore == FOUND_SECRETS
+    assert cache.last_found_secrets == FOUND_SECRETS
+
+
+@patch("ggshield.config.Config.CONFIG_LOCAL", ["/tmp/.gitguardian.yml"])
+@patch("ggshield.config.Config.DEFAULT_CONFIG_LOCAL", "/tmp/.gitguardian.yml")
+def test_ignore_last_found_with_manually_added_secrets(client):
+    """
+    GIVEN a cache containing part of config ignored-matches secrets
+    WHEN I run ignore command
+    THEN only new discovered secrets are added to the config
+    """
+    manually_added_secret = "m42ploz2wd"
+    config = Config()
+    config.matches_ignore = {manually_added_secret}
+    cache = Cache()
+    cache.last_found_secrets = FOUND_SECRETS
+
+    ignore_last_found(config, cache)
+
+    assert config.matches_ignore == FOUND_SECRETS
+
+
+@patch("ggshield.config.Config.CONFIG_LOCAL", ["/tmp/.gitguardian.yml"])
+@patch("ggshield.config.Config.DEFAULT_CONFIG_LOCAL", "/tmp/.gitguardian.yml")
+def test_ignore_last_found_preserve_previous_config(client):
+    """
+    GIVEN a cache containing new secrets AND a config not empty
+    WHEN I run ignore command
+    THEN existing config option are not wiped out
+    """
+    config = Config()
+    previous_secrets = {"previous_secret", "other_previous_secret"}
+    previous_paths = {"some_path", "some_other_path"}
+    config.matches_ignore = previous_secrets
+    config.paths_ignore = previous_paths
+    config.exit_zero = True
+
+    cache = Cache()
+    cache.last_found_secrets = FOUND_SECRETS
+
+    ignore_last_found(config, cache)
+
+    assert config.matches_ignore == FOUND_SECRETS.union(previous_secrets)
+    assert config.paths_ignore == previous_paths
+    assert config.exit_zero is True


### PR DESCRIPTION
### Add last run cache and ignore latest found secrets

__Narrative__
As a ggshield user,

I want to add my last found secrets on ggshield to the .gitguardian.yaml (or .gitguardian.yml) when I run ggshield ignore --last-found

so that I don't have to copy-paste them into .gitguardian.yaml and they are ignored on my next run of ggshield


__Technical description:__
- add Cache object that load and save into a local json .cache_ggshield file
- add ignore cmd with its option --last-found
- add corresponding doc in README.md
- adding comment to the config yaml turned out to be too complicated compared to the value of the feature