### PR TITLE
fix(ggshield): allow execution of local hooks when the global hook runs

### DIFF
--- a/ggshield/install.py
+++ b/ggshield/install.py
@@ -70,9 +70,9 @@ def create_hook(hook_dir_path: str, force: bool, local_hook_support: bool) -> in
             "{} already exists. Use --force to override.".format(hook_path)
         )
 
-    local_hook_guard=''
+    local_hook_str = ""
     if local_hook_support:
-        local_hook_guard = """
+        local_hook_str = """
 if [[ -f .git/hooks/pre-commit ]]; then
     if ! .git/hooks/pre-commit $@; then
         echo 'Local pre-commit hook failed, please see output above'
@@ -81,7 +81,7 @@ if [[ -f .git/hooks/pre-commit ]]; then
 fi
 """
     with open(hook_path, "w") as f:
-        f.write("#!/bin/bash\n\n{}\nggshield scan pre-commit\n".format(local_hook_guard))
+        f.write("#!/bin/bash\n\n{}\nggshield scan pre-commit\n".format(local_hook_str))
         os.chmod(hook_path, 0o700)
 
     click.echo(


### PR DESCRIPTION
Hi,

Thanks for creating this cool tool. I wanted to propose a fix for the global hook installation.
If certain repos have local pre commit hooks installed (manually or through some other tools), the global pre-commit hook completely ignores them, leading to bad user experience since these pre-commit hooks are installed for a reason.

With this proposed change, local hooks are executed if they exist:

```
perei@DESKTOP-9PBJQMM MINGW64 ~/Documents/gg-shield (local-hook-support-for-global)
$ docker build -t ggshield .
[+] Building 16.0s (19/19) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                  0.0s
 => => transferring dockerfile: 32B                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                     0.0s
 => => transferring context: 34B                                                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/python:3.8-slim-buster                                                                                             0.4s
 => [internal] load metadata for docker.io/library/python:3.8-buster                                                                                                  0.4s
 => [stage-1 1/7] FROM docker.io/library/python:3.8-slim-buster@sha256:60d8ae7490dc6be75ad9ed8b504cd8835be12f9a828b2b9fe0e19e4d66b6f636                               0.0s
 => [internal] load build context                                                                                                                                     0.0s
 => => transferring context: 4.25kB                                                                                                                                   0.0s
 => [build 1/6] FROM docker.io/library/python:3.8-buster@sha256:4e64ee201621e2ad8308f57cab9c22013676d78630548e9ae43b1937025e864d                                      0.0s
 => CACHED [build 2/6] WORKDIR /app                                                                                                                                   0.0s
 => CACHED [build 3/6] RUN set -e ;     apt-get update ;     apt-get dist-upgrade -y --no-install-recommends ;     apt-get autoremove -y ;     apt-get clean ;     p  0.0s
 => [build 4/6] COPY . ./                                                                                                                                             0.0s
 => [build 5/6] RUN sed -i '/editable/d' Pipfile.lock                                                                                                                 0.2s
 => [build 6/6] RUN pipenv install --ignore-pipfile                                                                                                                  14.7s
 => CACHED [stage-1 2/7] RUN set -e ;     apt-get update ;     apt-get dist-upgrade -y --no-install-recommends ;     apt-get install -y --no-install-recommends git   0.0s
 => CACHED [stage-1 3/7] WORKDIR /app                                                                                                                                 0.0s
 => CACHED [stage-1 4/7] RUN set -ex;     groupadd -g 1337 app;     useradd -u 1337 -g 1337 -b /home -c "GitGuardian App User" -m -s /bin/sh app;     mkdir /data; c  0.0s
 => [stage-1 5/7] COPY --from=build /app/.venv /app/.venv                                                                                                             0.1s
 => [stage-1 6/7] COPY ./ ./                                                                                                                                          0.0s
 => [stage-1 7/7] WORKDIR /data                                                                                                                                       0.0s
 => exporting to image                                                                                                                                                0.2s
 => => exporting layers                                                                                                                                               0.2s
 => => writing image sha256:bc145bd1e090dc2cff041c1fcf758da2adcdde3bfeefe23520670b3f12a3bcae                                                                          0.0s
 => => naming to docker.io/library/ggshield                                                                                                                           0.0s

perei@DESKTOP-9PBJQMM MINGW64 ~/Documents/gg-shield (local-hook-support-for-global)
$ docker run --rm -it ggshield bash
root@923e0762f64a:/data# cd /app
root@923e0762f64a:/app# ggshield install -m global
pre-commit successfully added in /root/.git/hooks/pre-commit
root@923e0762f64a:/app# ^C
root@923e0762f64a:/app# cat /root/.git/hooks/pre-commit
#!/bin/bash


if [[ -f .git/hooks/pre-commit ]]; then
    if ! .git/hooks/pre-commit $@; then
        echo 'Local pre-commit hook failed, please see output above'
        exit 1
    fi
fi

ggshield scan pre-commit
root@923e0762f64a:/app# mkdir /tmp/test
root@923e0762f64a:/app# cd /tmp/test
root@923e0762f64a:/tmp/test# git init .
Initialized empty Git repository in /tmp/test/.git/
root@923e0762f64a:/tmp/test# echo 'echo I am a local pre commit' > .git/hooks/pre-commit
root@923e0762f64a:/tmp/test# chmod +x .git/hooks/pre-commit
root@923e0762f64a:/tmp/test# git config --global user.email email@mail.com
root@923e0762f64a:/tmp/test# git config --global user.name demo
root@923e0762f64a:/tmp/test# echo toto > toto && git add toto && git commit -m test
I am a local pre commit
Error: GitGuardian API Key is needed.
```