### PR TITLE
Proposed fix for Issue 52

### DIFF
--- a/ggshield/git_shell.py
+++ b/ggshield/git_shell.py
@@ -21,7 +21,9 @@ def get_git_path(cwd: str) -> str:
     # insensitive filesystems but detection is problematic
     git_path = os.path.abspath(git_path)
     cwd = os.path.abspath(cwd)
-    path_env = list(map(os.path.abspath, os.environ.get("PATH", "").split(os.pathsep)))
+    path_env = [
+        os.path.abspath(p) for p in os.environ.get("PATH", "").split(os.pathsep)
+    ]
 
     # git was found - ignore git in cwd if cwd not in PATH
     if cwd == os.path.dirname(git_path) and cwd not in path_env:


### PR DESCRIPTION
This is in reference to https://github.com/GitGuardian/gg-shield/issues/52

Don't throw exception when CWD is /
Do throw an exception when git is not found
Update exception message to indicate situation (not found vs rejected)
Enhance PATH/CWD comparisons to avoid symlinks from causing issues
