### PR TITLE
Make dockerfile/buildargs specific

### DIFF
--- a/ggshield/scan/docker.py
+++ b/ggshield/scan/docker.py
@@ -83,7 +83,7 @@ def _get_config(archive: tarfile.TarFile) -> Tuple[Dict, Dict, File]:
         json.loads(config_file_content),
         File(
             config_file_content,
-            filename=os.path.join(archive.name, config_file_path),  # type: ignore
+            filename="Dockerfile or build-args",  # noqa: E501
             filesize=config_file_info.size,
         ),
     )

--- a/tests/scan/test_scan_docker.py
+++ b/tests/scan/test_scan_docker.py
@@ -78,17 +78,17 @@ class TestDockerScan:
         files = get_files_from_docker_archive(DOCKER_EXAMPLE_PATH)
 
         expected_files = {
-            "6f19b02ab98ac5757d206a2f0f5a4741ad82d39b08b948321196988acb9de8b1.json": None,  # noqa: E501
-            "64a345482d74ea1c0699988da4b4fe6cda54a2b0ad5da49853a9739f7a7e5bbc/layer.tar/app/file_one": "Hello, I am the first file!\n",  # noqa: E501
-            "2d185b802fb3c2e6458fe1ac98e027488cd6aedff2e3d05eb030029c1f24d60f/layer.tar/app/file_three.sh": "echo Life is beautiful.\n",  # noqa: E501
-            "2d185b802fb3c2e6458fe1ac98e027488cd6aedff2e3d05eb030029c1f24d60f/layer.tar/app/file_two.py": """print("Hi! I'm the second file but I'm happy.")\n""",  # noqa: E501
+            "Dockerfile or build-args": None,  # noqa: E501
+            DOCKER_EXAMPLE_PATH
+            / "64a345482d74ea1c0699988da4b4fe6cda54a2b0ad5da49853a9739f7a7e5bbc/layer.tar/app/file_one": "Hello, I am the first file!\n",  # noqa: E501
+            DOCKER_EXAMPLE_PATH
+            / "2d185b802fb3c2e6458fe1ac98e027488cd6aedff2e3d05eb030029c1f24d60f/layer.tar/app/file_three.sh": "echo Life is beautiful.\n",  # noqa: E501
+            DOCKER_EXAMPLE_PATH
+            / "2d185b802fb3c2e6458fe1ac98e027488cd6aedff2e3d05eb030029c1f24d60f/layer.tar/app/file_two.py": """print("Hi! I'm the second file but I'm happy.")\n""",  # noqa: E501
         }
 
-        assert set(files.files) == {
-            str(DOCKER_EXAMPLE_PATH / file_path) for file_path in expected_files
-        }
+        assert set(files.files) == {str(file_path) for file_path in expected_files}
 
         for file_path, expected_content in expected_files.items():
-            full_path = DOCKER_EXAMPLE_PATH / file_path
-            file = files.files[str(full_path)]
+            file = files.files[str(file_path)]
             assert expected_content is None or file.document == expected_content


### PR DESCRIPTION
- Make dockerfile/buildargs specific in the detection
- Easiest way without changing output logic

Example:

![docker-scan](https://user-images.githubusercontent.com/8071073/122930293-25db7480-d36c-11eb-8dda-8114697177cb.png)
